### PR TITLE
Update KSP-AVC file to say KSP 1.3.0

### DIFF
--- a/GameData/Analog Control Continued/AnalogControl.version
+++ b/GameData/Analog Control Continued/AnalogControl.version
@@ -1,1 +1,7 @@
-{"NAME":"Analog Control","URL":"https://github.com/Crzyrndm/Analog-Control/blob/master/GameData/Analog%20Control/AnalogControl.version","DOWNLOAD":"https://github.com/Crzyrndm/Analog-Control/releases","VERSION":{"MAJOR":2,"MINOR":1,"PATCH":2,"BUILD":0},"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":2}}
+{
+    "NAME":"Analog Control",
+    "URL":"https://github.com/Crzyrndm/Analog-Control/blob/master/GameData/Analog%20Control/AnalogControl.version",
+    "DOWNLOAD":"https://github.com/Crzyrndm/Analog-Control/releases",
+    "VERSION":{"MAJOR":2,"MINOR":1,"PATCH":2,"BUILD":0},
+    "KSP_VERSION":{"MAJOR":1,"MINOR":3,"PATCH":0}
+}


### PR DESCRIPTION
This version is supposed to be KSP 1.3.0 only, see:

https://github.com/KSP-CKAN/NetKAN/issues/5824